### PR TITLE
removing files that don't need to be tracked

### DIFF
--- a/ccr/.gitignore
+++ b/ccr/.gitignore
@@ -1,0 +1,6 @@
+target/
+.idea/
+.settings/
+.classpath
+.project
+*.iml


### PR DESCRIPTION
We don't need to track binaries in `target` or Eclipse-specific or IntelliJ-specific project files.